### PR TITLE
[codex] Add optional skill auto publish after review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ distribution/conf/*.sql
 distribution/plugins/*.jar
 dependency-reduced-pom.xml
 .jqwik-database
+.qoder/
+openspec/

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.AiResourceConstants;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
 import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.model.PipelineCallback;
 import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
 import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
 import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
@@ -687,8 +688,17 @@ public class AiResourceManager {
      */
     public AiResourceVersion doPublish(String namespaceId, String name, String type, String version,
             boolean updateLatestLabel) throws NacosException {
+        return doPublish(namespaceId, name, type, version, updateLatestLabel, true,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
+    }
+
+    private AiResourceVersion doPublish(String namespaceId, String name, String type, String version,
+            boolean updateLatestLabel, boolean checkVisibility, String operator, String clientIp)
+            throws NacosException {
         AiResource meta = requireMeta(namespaceId, name, type);
-        VisibilityHelper.checkWritableResource(meta);
+        if (checkVisibility) {
+            VisibilityHelper.checkWritableResource(meta);
+        }
         ResourceVersionInfo info = requireVersionInfo(meta);
         
         AiResourceVersion v = aiResourceVersionPersistService.find(namespaceId, name, type, version);
@@ -734,9 +744,18 @@ public class AiResourceManager {
             info.getLabels().put(AiResourceConstants.LABEL_LATEST, version);
         }
         updateVersionInfoCas(namespaceId, meta, info);
-        AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_PUBLISH,
-                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
+        AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_PUBLISH, operator, clientIp);
         return v;
+    }
+
+    /**
+     * Core publish logic for system-triggered pipeline callbacks.
+     *
+     * @return the version row (caller may need it for post-processing, e.g. manifest sync)
+     */
+    public AiResourceVersion doSystemPublish(String namespaceId, String name, String type, String version,
+            boolean updateLatestLabel) throws NacosException {
+        return doPublish(namespaceId, name, type, version, updateLatestLabel, false, "system", "");
     }
     
     /**
@@ -980,10 +999,21 @@ public class AiResourceManager {
      */
     public boolean runPipelineExecution(String namespaceId, String name, String type, String version,
             ResourceFilesPipelineContext ctx, PublishPipelineExecutor executor) {
+        return runPipelineExecution(namespaceId, name, type, version, ctx, executor,
+                r -> onPipelineComplete(namespaceId, name, type, version, r));
+    }
+
+    /**
+     * Execute the publish pipeline for a resource version with a caller-provided completion callback.
+     *
+     * <p>The initial IN_PROGRESS record is still written here so the version can expose a stable executionId
+     * before async execution starts.</p>
+     */
+    public boolean runPipelineExecution(String namespaceId, String name, String type, String version,
+            ResourceFilesPipelineContext ctx, PublishPipelineExecutor executor, PipelineCallback callback) {
         String executionId = UUID.randomUUID().toString();
         writePipelineInfoInProgress(namespaceId, name, type, version, executionId);
-        String result = executor.execute(ctx,
-                r -> onPipelineComplete(namespaceId, name, type, version, r), executionId);
+        String result = executor.execute(ctx, callback, executionId);
         if (StringUtils.isBlank(result)) {
             clearPipelineInfo(namespaceId, name, type, version);
             return false;

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -23,6 +23,8 @@ import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
 import com.alibaba.nacos.ai.model.skills.SkillIndexManifest;
 import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
 import com.alibaba.nacos.ai.service.VisibilityHelper;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
@@ -105,6 +107,9 @@ public class SkillOperationServiceImpl implements SkillOperationService {
      * different storage providers via service-level configuration.</p>
      */
     private static final String SKILL_STORAGE_PROVIDER_CONFIG_KEY = "nacos.ai.skill.storage.provider";
+
+    private static final String AUTO_PUBLISH_AFTER_REVIEW_ENABLED_KEY =
+            "nacos.ai.skill.auto-publish-after-review.enabled";
 
     private static final String RESOURCE_TYPE_SKILL = "skill";
 
@@ -785,11 +790,40 @@ public class SkillOperationServiceImpl implements SkillOperationService {
 
         // Step 6: Run pipeline asynchronously; fall back to direct publish if startup fails
         if (!resourceManager.runPipelineExecution(namespaceId, name, RESOURCE_TYPE_SKILL, finalTarget,
-                ctx, publishPipelineExecutor)) {
+                ctx, publishPipelineExecutor,
+                r -> onSkillPipelineComplete(namespaceId, name, finalTarget, r))) {
             publish(namespaceId, name, finalTarget, true);
         }
 
         return finalTarget;
+    }
+
+    private void onSkillPipelineComplete(String namespaceId, String name, String version,
+            PipelineExecutionResult result) {
+        resourceManager.onPipelineComplete(namespaceId, name, RESOURCE_TYPE_SKILL, version, result);
+        if (result == null || result.getStatus() != PipelineExecutionStatus.APPROVED) {
+            return;
+        }
+        if (!EnvUtil.getProperty(AUTO_PUBLISH_AFTER_REVIEW_ENABLED_KEY, Boolean.class, false)) {
+            return;
+        }
+        try {
+            publishApprovedBySystem(namespaceId, name, version, true);
+        } catch (Throwable ex) {
+            LOGGER.error("Failed to auto publish approved skill {}@{}", name, version, ex);
+        }
+    }
+
+    private void publishApprovedBySystem(String namespaceId, String name, String version, boolean updateLatestLabel)
+            throws NacosException {
+        AiResourceVersion v = resourceManager.doSystemPublish(namespaceId, name, RESOURCE_TYPE_SKILL, version,
+                updateLatestLabel);
+        SkillIndexManifest manifest = manifestService.loadForUpdate(namespaceId, name);
+        manifest.getVersions().put(version, parseStorageFiles(v.getStorage()));
+        if (updateLatestLabel) {
+            manifest.getLabels().put(AiResourceConstants.LABEL_LATEST, version);
+        }
+        manifestService.write(namespaceId, name, manifest);
     }
 
     /**

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -20,7 +20,11 @@ import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
 import com.alibaba.nacos.ai.pipeline.PublishPipelineManager;
 import com.alibaba.nacos.ai.pipeline.config.PipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.model.PipelineCallback;
 import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
 import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
@@ -95,6 +99,9 @@ import static org.mockito.Mockito.when;
  */
 @ExtendWith(MockitoExtension.class)
 class SkillOperationServiceImplTest {
+
+    private static final String AUTO_PUBLISH_AFTER_REVIEW_ENABLED_KEY =
+            "nacos.ai.skill.auto-publish-after-review.enabled";
     
     @Mock
     private AiResourceStorage storage;
@@ -149,6 +156,7 @@ class SkillOperationServiceImplTest {
         if (visibilityManagerStatic != null) {
             visibilityManagerStatic.close();
         }
+        System.clearProperty(AUTO_PUBLISH_AFTER_REVIEW_ENABLED_KEY);
         EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
     }
     
@@ -1524,6 +1532,136 @@ class SkillOperationServiceImplTest {
         assertEquals("v1", result);
         verify(aiResourceVersionPersistService).updateStatus(eq(namespaceId), eq(skillName), anyString(),
                 eq("v1"), eq("online"));
+    }
+
+    @Test
+    void testSubmitAutoPublishWhenPipelineApproved() throws NacosException {
+        System.setProperty(AUTO_PUBLISH_AFTER_REVIEW_ENABLED_KEY, "true");
+        VisibilityService visibilityService = mock(VisibilityService.class);
+        when(visibilityService.validateVisibility(anyString(), anyString(), anyString(), any()))
+                .thenReturn(ValidationResult.allow());
+        when(mockVisibilityManager.findVisibilityService(anyString())).thenReturn(Optional.of(visibilityService));
+        String namespaceId = "test-ns";
+        String skillName = "my-skill";
+        AiResource meta = new AiResource();
+        meta.setName(skillName);
+        meta.setType("skill");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"editingVersion\":\"v1\",\"labels\":{},\"onlineCnt\":0}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(skillName), anyString())).thenReturn(meta);
+        com.alibaba.nacos.ai.model.AiResourceVersion vRow = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        vRow.setVersion("v1");
+        vRow.setStatus("draft");
+        vRow.setStorage("{\"provider\":\"nacos_config\",\"scope\":\"ns:s:v1\",\"files\":[\"SKILL.md\"]}");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(), eq("v1")))
+                .thenReturn(vRow);
+        when(storage.get(any(StorageKey.class))).thenReturn(
+                ("---\nname: my-skill\ndescription: desc\n---\n\nbody").getBytes());
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq(skillName), eq("skill"), anyLong(), any()))
+                .thenReturn(true);
+        doAnswer(invocation -> {
+            vRow.setStatus(invocation.getArgument(4));
+            return null;
+        }).when(aiResourceVersionPersistService).updateStatus(eq(namespaceId), eq(skillName), anyString(),
+                eq("v1"), anyString());
+        doAnswer(invocation -> {
+            vRow.setPublishPipelineInfo(invocation.getArgument(4));
+            return null;
+        }).when(aiResourceVersionPersistService).updatePublishPipelineInfo(eq(namespaceId), eq(skillName),
+                anyString(), eq("v1"), anyString());
+
+        PipelineExecution execution = new PipelineExecution();
+        execution.setExecutionId("exec-1");
+        execution.setStatus(PipelineExecutionStatus.APPROVED);
+        when(pipelineExecutionRepository.findById("exec-1")).thenReturn(execution);
+        com.alibaba.nacos.ai.model.skills.SkillIndexManifest manifest =
+                new com.alibaba.nacos.ai.model.skills.SkillIndexManifest();
+        manifest.setVersions(new HashMap<>());
+        manifest.setLabels(new HashMap<>());
+        when(manifestService.loadForUpdate(eq(namespaceId), eq(skillName))).thenReturn(manifest);
+
+        PublishPipelineExecutor pipelineExecutor = mock(PublishPipelineExecutor.class);
+        when(pipelineExecutor.isPipelineAvailable(any())).thenReturn(true);
+        doAnswer(invocation -> {
+            PipelineCallback callback = invocation.getArgument(1);
+            PipelineExecutionResult result = new PipelineExecutionResult();
+            result.setExecutionId("exec-1");
+            result.setStatus(PipelineExecutionStatus.APPROVED);
+            result.setPipeline(List.of());
+            callback.onComplete(result);
+            return "exec-1";
+        }).when(pipelineExecutor).execute(any(), any(), anyString());
+        SkillOperationServiceImpl autoPublishService = new SkillOperationServiceImpl(aiResourcePersistService,
+                aiResourceVersionPersistService, pipelineExecutor, manifestService,
+                new AiResourceManager(aiResourcePersistService, aiResourceVersionPersistService,
+                        pipelineExecutionRepository));
+
+        String result = autoPublishService.submit(namespaceId, skillName, null);
+
+        assertEquals("v1", result);
+        verify(aiResourceVersionPersistService).updateStatus(eq(namespaceId), eq(skillName), anyString(),
+                eq("v1"), eq("online"));
+        verify(manifestService).write(eq(namespaceId), eq(skillName), any());
+        verify(visibilityService, times(1)).validateVisibility(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void testSubmitShouldNotAutoPublishByDefaultWhenPipelineApproved() throws NacosException {
+        String namespaceId = "test-ns";
+        String skillName = "my-skill";
+        AiResource meta = new AiResource();
+        meta.setName(skillName);
+        meta.setType("skill");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"editingVersion\":\"v1\",\"labels\":{},\"onlineCnt\":0}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(skillName), anyString())).thenReturn(meta);
+        com.alibaba.nacos.ai.model.AiResourceVersion vRow = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        vRow.setVersion("v1");
+        vRow.setStatus("draft");
+        vRow.setStorage("{\"provider\":\"nacos_config\",\"scope\":\"ns:s:v1\",\"files\":[\"SKILL.md\"]}");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(), eq("v1")))
+                .thenReturn(vRow);
+        when(storage.get(any(StorageKey.class))).thenReturn(
+                ("---\nname: my-skill\ndescription: desc\n---\n\nbody").getBytes());
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq(skillName), eq("skill"), anyLong(), any()))
+                .thenReturn(true);
+        doAnswer(invocation -> {
+            vRow.setStatus(invocation.getArgument(4));
+            return null;
+        }).when(aiResourceVersionPersistService).updateStatus(eq(namespaceId), eq(skillName), anyString(),
+                eq("v1"), anyString());
+        doAnswer(invocation -> {
+            vRow.setPublishPipelineInfo(invocation.getArgument(4));
+            return null;
+        }).when(aiResourceVersionPersistService).updatePublishPipelineInfo(eq(namespaceId), eq(skillName),
+                anyString(), eq("v1"), anyString());
+
+        PublishPipelineExecutor pipelineExecutor = mock(PublishPipelineExecutor.class);
+        when(pipelineExecutor.isPipelineAvailable(any())).thenReturn(true);
+        doAnswer(invocation -> {
+            PipelineCallback callback = invocation.getArgument(1);
+            PipelineExecutionResult result = new PipelineExecutionResult();
+            result.setExecutionId("exec-1");
+            result.setStatus(PipelineExecutionStatus.APPROVED);
+            result.setPipeline(List.of());
+            callback.onComplete(result);
+            return "exec-1";
+        }).when(pipelineExecutor).execute(any(), any(), anyString());
+        SkillOperationServiceImpl autoPublishService = new SkillOperationServiceImpl(aiResourcePersistService,
+                aiResourceVersionPersistService, pipelineExecutor, manifestService,
+                new AiResourceManager(aiResourcePersistService, aiResourceVersionPersistService,
+                        pipelineExecutionRepository));
+
+        String result = autoPublishService.submit(namespaceId, skillName, null);
+
+        assertEquals("v1", result);
+        verify(aiResourceVersionPersistService, never()).updateStatus(eq(namespaceId), eq(skillName), anyString(),
+                eq("v1"), eq("online"));
+        verify(manifestService, never()).write(eq(namespaceId), eq(skillName), any());
     }
     
     @Test

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -380,6 +380,8 @@ nacos.istio.mcp.server.enabled=false
 #nacos.plugin.ai-pipeline.skill-scanner.enabled=true
 # Optional: specify an absolute executable path when PATH resolution differs between shell and server process.
 #nacos.plugin.ai-pipeline.skill-scanner.command=/Users/your-user/.local/bin/skill-scanner
+# Optional: auto-publish skill versions after pipeline approval, default false.
+#nacos.ai.skill.auto-publish-after-review.enabled=false
 
 #--------------- Nacos Experimental Features Configurations ---------------#
 


### PR DESCRIPTION
## Summary

This PR adds an opt-in switch for skill versions to be published automatically after the review pipeline approves them.

## Changes

- Add `nacos.ai.skill.auto-publish-after-review.enabled`, defaulting to `false` for compatibility.
- Route skill pipeline completion through a skill-specific callback that publishes approved versions only when the switch is enabled.
- Add a system publish path for pipeline callbacks so auto-publish does not depend on request-scoped user visibility context.
- Document the new property in `distribution/conf/application.properties`.
- Ignore local tool directories `.qoder/` and `openspec/`.

## Validation

- `git diff --cached --check`
- `mvn -pl ai -Dtest=SkillOperationServiceImplTest#testSubmitAutoPublishWhenPipelineApproved+testSubmitShouldNotAutoPublishByDefaultWhenPipelineApproved test`

## Notes

`pom.xml` local version change for packaging/debugging was intentionally not included in this PR.
